### PR TITLE
Release for v1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-approval",
-  "version": "v1.0.1",
+  "version": "v1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "slack-approval",
-      "version": "v1.0.1",
+      "version": "v1.1.0",
       "license": "ISC",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-approval",
-  "version": "v1.0.1",
+  "version": "v1.1.0",
   "description": "Custom action to send approval request to Slack",
   "scripts": {
     "bundle": "npm run format && npm run lint && npm run check && npm run package",


### PR DESCRIPTION
This pull request is for the next release as v1.1.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.1.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v1.0.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* feat: Add authorized-users by @Takashicc in https://github.com/Takashicc/slack-approval/pull/15


**Full Changelog**: https://github.com/Takashicc/slack-approval/compare/v1.0.1...v1.1.0