### PR TITLE
Release for v2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1625,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "slack-approval"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "envy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slack-approval"
-version = "1.1.0"
+version = "2.0.0"
 edition = "2021"
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > [!WARNING]
 > UNDER CONSTRUCTION!
 > Please reference the [older version README](https://github.com/Takashicc/slack-approval/blob/298fa3048bf704e769b8195396433c094b5d9668/README.md).
-> Also, Use the `Takashicc/slack-approval@v1.1.0`. NOT `main`.
+> Also, Use the `Takashicc/slack-approval@v2.0.0`. NOT `main`.
 
 Custom action to send approval request to Slack.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > [!WARNING]
 > UNDER CONSTRUCTION!
 > Please reference the [older version README](https://github.com/Takashicc/slack-approval/blob/298fa3048bf704e769b8195396433c094b5d9668/README.md).
-> Also, Use the `Takashicc/slack-approval@v2.0.0`. NOT `main`.
+> Also, Use the `Takashicc/slack-approval@v1.1.0`. NOT `main`.
 
 Custom action to send approval request to Slack.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > [!WARNING]
 > UNDER CONSTRUCTION!
 > Please reference the [older version README](https://github.com/Takashicc/slack-approval/blob/298fa3048bf704e769b8195396433c094b5d9668/README.md).
-> Also, Use the `Takashicc/slack-approval@v2.0.0`. NOT `main`.
+> Also, Use the `Takashicc/slack-approval@v1.1.0`. NOT `main`.
 
 Custom action to send approval request to Slack.
 
@@ -25,7 +25,7 @@ jobs:
   approval:
     runs-on: ubuntu-latest
     steps:
-      - uses: Takashicc/slack-approval@v1.1.0
+      - uses: Takashicc/slack-approval@v2.0.0
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           app-token: ${{ secrets.SLACK_APP_TOKEN }}


### PR DESCRIPTION
This pull request is for the next release as v2.0.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v2.0.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v1.1.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed

* feat: Replace to container action by @Takashicc in https://github.com/Takashicc/slack-approval/pull/100
* fix(deps): update rust deps by @renovate in https://github.com/Takashicc/slack-approval/pull/108
* chore: Pass GitHub token to tagpr by @Takashicc in https://github.com/Takashicc/slack-approval/pull/110
* chore(deps): pin dependencies by @renovate in https://github.com/Takashicc/slack-approval/pull/107
* chore: Change current version to v1.1.0 by @Takashicc in https://github.com/Takashicc/slack-approval/pull/112
* chore(deps): update rust docker tag to v1.84.0 by @renovate in https://github.com/Takashicc/slack-approval/pull/113
* fix: Change the underscore to dash for github inputs. by @Takashicc in https://github.com/Takashicc/slack-approval/pull/116
* fix: Remove unnecessary lifetime annotations by @Takashicc in https://github.com/Takashicc/slack-approval/pull/118
* chore(deps): update docker/build-push-action digest to ca877d9 by @renovate in https://github.com/Takashicc/slack-approval/pull/117
* feat: Add publish workflow by @Takashicc in https://github.com/Takashicc/slack-approval/pull/114
* chore(deps): pin dependencies by @renovate in https://github.com/Takashicc/slack-approval/pull/119

**Full Changelog**: https://github.com/Takashicc/slack-approval/compare/v1.1.0...v2.0.0